### PR TITLE
Updating requirements.txt for herBAR prior to TACC demo on 2022-07-15

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,15 @@ A barcode renamer for herbarium specimens
 ### Requirements
 
 Python 3.*  
+
 Pillow >= 7.0.0
+
 zbar
+
 pyzbar >= 0.1.9
+
 tqdm >= 4.64.0
+
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ A barcode renamer for herbarium specimens
 ### Requirements
 
 Python 3.*  
-Pillow  
-zbar  
+Pillow >= 7.0.0
+zbar
+pyzbar >= 0.1.9
+tqdm >= 4.64.0
 
 ### Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Pillow==7.2.0
-pyzbar==0.1.8
-tqdm
+Pillow>=7.0.0
+pyzbar>=0.1.9
+tqdm>=4.64.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Pillow>=7.0.0
-pyzbar>=0.1.9
-tqdm>=4.64.0
+Pillow==7.0.0
+pyzbar==0.1.9
+tqdm==4.64.0


### PR DESCRIPTION
Upon attempting to install herBAR from Master, I was initially unable to because, in the requirements.txt file, "pyzbar" was referred to as simply "zbar", and "tqdm" was missing. Doing a simple "pip install pyzbar" and "pip install tqdm" solved these issues.

I have also updated the required versions for each of the programs, based on what I currently have installed on my system (from the output of "pip freeze"): Pillow works with an older version (7.0.0, instead of 7.2.0), pyzbar is now at 0.1.9 (instead of 0.1.8), and I have also added the version of tqdm that I currently have on my system (4.64.0). Thanks!